### PR TITLE
Only build against and depend on fabric-resource-loader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     include "me.shedaniel.cloth:cloth-config-fabric:${project.clothconfig_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    modImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 }
 
 processResources {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
     "TieFix.mixins.json"
   ],
   "depends": {
-    "fabric": "*",
+    "fabric-resource-loader-v0": "*",
     "minecraft": "1.18.x"
   },
   "recommends": {


### PR DESCRIPTION
In development environment that contains this mod, the whole of Fabric API is required. It would be easier to just depend on fabric resource loader for mod developers, since this fixes multiple bugs, which makes debugging through chat on UNIX so much easier.